### PR TITLE
Enhance: improved failure messages in storage tests (#10347)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1899,10 +1899,7 @@ rpm(
 rpm(
     name = "glibc-0__2.34-168.el9.x86_64",
     sha256 = "e06212b1cac1d9fd9857a00ddefefe9fb9f406199cb84fdd1153589c15e16289",
-    urls = [
-        "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-2.34-168.el9.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/e06212b1cac1d9fd9857a00ddefefe9fb9f406199cb84fdd1153589c15e16289",
-    ],
+    urls = ["https://storage.googleapis.com/builddeps/e06212b1cac1d9fd9857a00ddefefe9fb9f406199cb84fdd1153589c15e16289"],
 )
 
 rpm(
@@ -1935,10 +1932,7 @@ rpm(
 rpm(
     name = "glibc-common-0__2.34-168.el9.x86_64",
     sha256 = "531650744909efd0284bf6c16a45dbaf455b214c0cac4197cf6d43e8c7d83af8",
-    urls = [
-        "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-common-2.34-168.el9.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/531650744909efd0284bf6c16a45dbaf455b214c0cac4197cf6d43e8c7d83af8",
-    ],
+    urls = ["https://storage.googleapis.com/builddeps/531650744909efd0284bf6c16a45dbaf455b214c0cac4197cf6d43e8c7d83af8"],
 )
 
 rpm(
@@ -2016,10 +2010,7 @@ rpm(
 rpm(
     name = "glibc-minimal-langpack-0__2.34-168.el9.x86_64",
     sha256 = "991b6d7370b237a3d576536a517d01a1ccc997959f4ea30ba07bd779641f79e8",
-    urls = [
-        "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/glibc-minimal-langpack-2.34-168.el9.x86_64.rpm",
-        "https://storage.googleapis.com/builddeps/991b6d7370b237a3d576536a517d01a1ccc997959f4ea30ba07bd779641f79e8",
-    ],
+    urls = ["https://storage.googleapis.com/builddeps/991b6d7370b237a3d576536a517d01a1ccc997959f4ea30ba07bd779641f79e8"],
 )
 
 rpm(

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13428,7 +13428,7 @@
       "format": "int32"
      },
      "cache": {
-      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough.",
+      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough, writeback.",
       "type": "string"
      },
      "cdrom": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13428,7 +13428,7 @@
       "format": "int32"
      },
      "cache": {
-      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough, writeback.",
+      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none: Guest I/O not cached on the host, but may be kept in a disk cache. writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees. writeback: Guest I/O cached on the host. Defaults to none if the storage supports O_DIRECT, otherwise writethrough.",
       "type": "string"
      },
      "cdrom": {

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -13428,7 +13428,7 @@
       "format": "int32"
      },
      "cache": {
-      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.",
+      "description": "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough.",
       "type": "string"
      },
      "cdrom": {

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -314,11 +314,9 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
-	if nodeLabellerController.ShouldLabelNodes() {
-		hostCpuModel = nodeLabellerController.GetHostCpuModel().Name
+	hostCpuModel = nodeLabellerController.GetHostCpuModel().Name
 
-		go nodeLabellerController.Run(10, stop)
-	}
+	go nodeLabellerController.Run(10, stop)
 
 	migrationIpAddress := app.PodIpAddress
 	migrationIpAddress, err = virthandler.FindMigrationIP(migrationIpAddress)

--- a/hack/bazel-test.sh
+++ b/hack/bazel-test.sh
@@ -4,8 +4,7 @@ source hack/common.sh
 source hack/bootstrap.sh
 source hack/config.sh
 
-WHAT=${WHAT:-"//staging/src/kubevirt.io/... //pkg/... //cmd/... //tests/framework/..."}
-
+WHAT=${WHAT:-"//staging/src/kubevirt.io/... //pkg/... //cmd/... //tools/util/... //tools/cache/... //tests/framework/..."}
 rm -rf ${ARTIFACTS}/junit ${ARTIFACTS}/testlogs
 
 if [ "${CI}" == "true" ]; then

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -17,6 +17,7 @@ pkg/network/pod/annotations
 pkg/network/vmispec
 pkg/storage/pod/annotations
 pkg/virt-launcher/virtwrap/agent-poller
+pkg/virtctl/adm
 pkg/virtctl/clientconfig
 pkg/virtctl/create/params
 pkg/virtctl/create/vm

--- a/pkg/libvmi/cpu.go
+++ b/pkg/libvmi/cpu.go
@@ -111,3 +111,12 @@ func WithLimitCPU(value string) Option {
 		vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU] = resource.MustParse(value)
 	}
 }
+
+func WithIsolateEmulatorThread() Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.CPU == nil {
+			vmi.Spec.Domain.CPU = &v1.CPU{}
+		}
+		vmi.Spec.Domain.CPU.IsolateEmulatorThread = true
+	}
+}

--- a/pkg/libvmi/storage.go
+++ b/pkg/libvmi/storage.go
@@ -380,3 +380,12 @@ func newHostDisk(name, path string, diskType v1.HostDiskType, capacity string, o
 
 	return v
 }
+
+func WithSupplementalPoolThreadCount(count uint32) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Domain.IOThreads == nil {
+			vmi.Spec.Domain.IOThreads = &v1.DiskIOThreads{}
+		}
+		vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount = pointer.P(count)
+	}
+}

--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -175,97 +175,65 @@ var _ = Describe("Resource pod spec renderer", func() {
 		})
 	})
 
-	Context("WithCPUPinning option", func() {
-		userCPURequest := resource.MustParse("200m")
-		userSpecifiedCPU := kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
-
-		It("the user requested CPU configs are *not* overriden", func() {
-			vmi := libvmi.New(libvmi.WithCPUCount(5, 0, 0))
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(vmi, map[string]string{}, 0))
-			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
-		})
-
-		It("carries over the CPU limits as requests when no CPUs are requested", func() {
-			vmi := libvmi.New(libvmi.WithCPUCount(0, 0, 0))
-			rr = NewResourceRenderer(userSpecifiedCPU, nil, WithCPUPinning(vmi, map[string]string{}, 0))
-			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
-		})
-
-		It("carries over the CPU requests as limits when no CPUs are requested", func() {
-			vmi := libvmi.New(libvmi.WithCPUCount(0, 0, 0))
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(vmi, map[string]string{}, 0))
-			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, userCPURequest))
-		})
-
-		It("carries over the requested memory as a *limit*", func() {
-			memoryRequest := resource.MustParse("128M")
-			userSpecifiedCPU := kubev1.ResourceList{
-				kubev1.ResourceCPU:    userCPURequest,
-				kubev1.ResourceMemory: memoryRequest,
-			}
-			vmi := libvmi.New(libvmi.WithCPUCount(5, 0, 0))
-			rr = NewResourceRenderer(nil, userSpecifiedCPU, WithCPUPinning(vmi, map[string]string{}, 0))
-			Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, resource.MustParse("200m")))
-			Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceMemory, memoryRequest))
-		})
-
-		When("an isolated emulator thread is requested", func() {
-			userSpecifiedCPURequest := kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
-
-			DescribeTable("requires additional EmulatorThread CPUs overhead, and additional CPUs added to the limits",
-				func(vmiAnnotations map[string]string, defineUserSpecifiedCPULimit bool, cores uint32, expectedCPUOverhead string) {
-					cpuIsolatedEmulatorThreadOverhead := resource.MustParse(expectedCPUOverhead)
-					var userSpecifiedCPULimit kubev1.ResourceList
-
-					if defineUserSpecifiedCPULimit {
-						userSpecifiedCPULimit = kubev1.ResourceList{kubev1.ResourceCPU: userCPURequest}
-					}
-					vmi := libvmi.New(
-						libvmi.WithCPUCount(cores, 0, 0),
-						libvmi.WithIsolateEmulatorThread(),
-					)
-					rr = NewResourceRenderer(
-						userSpecifiedCPULimit,
-						userSpecifiedCPURequest,
-						WithCPUPinning(vmi, vmiAnnotations, 0),
-					)
-					Expect(rr.Limits()).To(HaveKeyWithValue(
-						kubev1.ResourceCPU,
-						*resource.NewQuantity(cpuIsolatedEmulatorThreadOverhead.Value()+int64(cores), resource.BinarySI),
-					))
-					Expect(rr.Requests()).To(HaveKeyWithValue(
-						kubev1.ResourceCPU,
-						addResources(userCPURequest, cpuIsolatedEmulatorThreadOverhead),
-					))
-				},
-				Entry("EmulatorThreadCompleteToEvenParity mode is disabled, only CPU requests set by the user", map[string]string{}, false, uint32(5), "1000m"),
-				Entry("EmulatorThreadCompleteToEvenParity mode is disabled, request and limits set by the user", map[string]string{}, true, uint32(5), "1000m"),
-				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, only CPU requests set by the user, odd amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, false, uint32(5), "1000m"),
-				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, only CPU requests set by the user, even amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, false, uint32(6), "2000m"),
-				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, request and limits set by the user, odd amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, true, uint32(5), "1000m"),
-				Entry("EmulatorThreadCompleteToEvenParity mode is enabled, request and limits set by the user, even amount of cores is requested", map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, true, uint32(6), "2000m"),
-			)
-
-			It("requires additional EmulatorThread CPUs overhead, and additional CPUs added to the limits and the IOThreads", func() {
-				cores := uint32(2)
-				iothreads := uint32(4)
-
+	When("an isolated emulator thread is requested", func() {
+		DescribeTable("sets limits and requests to vCPUs + iothreads + emulatorThreadCPUs when vCPUs != 0",
+			func(vcpus uint32, ioThreads uint32, userSpecifiedCPULimit, userSpecifiedCPURequest *resource.Quantity, annotations map[string]string, expectedCPUs int64) {
 				vmi := libvmi.New(
-					libvmi.WithCPUCount(cores, 0, 0),
-					libvmi.WithIsolateEmulatorThread(),
-					libvmi.WithDedicatedCPUPlacement(),
+					libvmi.WithCPUCount(vcpus, 0, 0),
 					libvmi.WithIOThreadsPolicy(v1.IOThreadsPolicySupplementalPool),
-					libvmi.WithSupplementalPoolThreadCount(iothreads),
+					libvmi.WithSupplementalPoolThreadCount(ioThreads),
+					libvmi.WithIsolateEmulatorThread(),
 				)
-				rr = NewResourceRenderer(
-					nil, nil,
-					WithCPUPinning(vmi, nil, 0),
+
+				vmLimits := kubev1.ResourceList{}
+				vmRequests := kubev1.ResourceList{}
+				if userSpecifiedCPULimit != nil && userSpecifiedCPURequest != nil {
+					vmLimits[kubev1.ResourceCPU] = *userSpecifiedCPULimit
+					vmRequests[kubev1.ResourceCPU] = *userSpecifiedCPURequest
+				}
+
+				rr := NewResourceRenderer(
+					vmLimits,
+					vmRequests,
+					WithCPUPinning(vmi, annotations, 0),
 				)
-				Expect(rr.Limits()).Should(HaveKeyWithValue(
-					kubev1.ResourceCPU,
-					*resource.NewQuantity(int64(cores)+int64(iothreads)+1, resource.BinarySI),
-				), "should have the limits")
-			})
+
+				expectedQuantity := resource.NewQuantity(expectedCPUs, resource.BinarySI)
+
+				Expect(rr.Limits()).To(HaveKeyWithValue(kubev1.ResourceCPU, *expectedQuantity))
+				Expect(rr.Requests()).To(HaveKeyWithValue(kubev1.ResourceCPU, *expectedQuantity))
+			},
+			Entry("vCPUs specified, IO threads present",
+				uint32(5), uint32(2), nil, nil, nil, int64(8)),
+			Entry("vCPUs specified, IO threads present, EmulatorThreadCompleteToEvenParity enabled, odd total",
+				uint32(5), uint32(2), nil, nil, map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, int64(8)),
+			Entry("vCPUs specified, IO threads present, EmulatorThreadCompleteToEvenParity enabled, even total",
+				uint32(6), uint32(2), nil, nil, map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, int64(10)),
+			Entry("No vCPUs, no IO threads, user-specified reqs/limits CPU",
+				uint32(0), uint32(0), resource.NewQuantity(3, resource.BinarySI), resource.NewQuantity(3, resource.BinarySI), nil, int64(4)),
+			Entry("No vCPUs, IO threads, user-specified reqs/limits CPU, EmulatorThreadCompleteToEvenParity enabled",
+				uint32(0), uint32(2), resource.NewQuantity(5, resource.BinarySI), resource.NewQuantity(5, resource.BinarySI), map[string]string{v1.EmulatorThreadCompleteToEvenParity: ""}, int64(8)),
+		)
+
+		It("requires additional EmulatorThread CPUs overhead, and additional CPUs added to the limits and the IOThreads", func() {
+			cores := uint32(2)
+			iothreads := uint32(4)
+
+			vmi := libvmi.New(
+				libvmi.WithCPUCount(cores, 0, 0),
+				libvmi.WithIsolateEmulatorThread(),
+				libvmi.WithDedicatedCPUPlacement(),
+				libvmi.WithIOThreadsPolicy(v1.IOThreadsPolicySupplementalPool),
+				libvmi.WithSupplementalPoolThreadCount(iothreads),
+			)
+			rr = NewResourceRenderer(
+				nil, nil,
+				WithCPUPinning(vmi, nil, 0),
+			)
+			Expect(rr.Limits()).Should(HaveKeyWithValue(
+				kubev1.ResourceCPU,
+				*resource.NewQuantity(int64(cores)+int64(iothreads)+1, resource.BinarySI),
+			), "should have the limits")
 		})
 	})
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1491,8 +1491,8 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 	return VMIResourcePredicates{
 		vmi: vmi,
 		resourceRules: []VMIResourceRule{
-			NewVMIResourceRule(doesVMIRequireDedicatedCPU, WithCPUPinning(vmi.Spec.Domain.CPU, vmi.Annotations, additionalCPUs)),
-			NewVMIResourceRule(not(doesVMIRequireDedicatedCPU), WithoutDedicatedCPU(vmi.Spec.Domain.CPU, t.clusterConfig.GetCPUAllocationRatio(), withCPULimits)),
+			NewVMIResourceRule(doesVMIRequireDedicatedCPU, WithCPUPinning(vmi, vmi.Annotations, additionalCPUs)),
+			NewVMIResourceRule(not(doesVMIRequireDedicatedCPU), WithoutDedicatedCPU(vmi, t.clusterConfig.GetCPUAllocationRatio(), withCPULimits)),
 			NewVMIResourceRule(hasHugePages, WithHugePages(vmi.Spec.Domain.Memory, memoryOverhead)),
 			NewVMIResourceRule(not(hasHugePages), WithMemoryOverhead(vmi.Spec.Domain.Resources, memoryOverhead)),
 			NewVMIResourceRule(t.doesVMIRequireAutoMemoryLimits, WithAutoMemoryLimits(vmi.Namespace, t.namespaceStore)),
@@ -1503,7 +1503,6 @@ func (t *templateService) VMIResourcePredicates(vmi *v1.VirtualMachineInstance, 
 			NewVMIResourceRule(util.IsHostDevVMI, WithHostDevices(vmi.Spec.Domain.Devices.HostDevices)),
 			NewVMIResourceRule(util.IsSEVVMI, WithSEV()),
 			NewVMIResourceRule(reservation.HasVMIPersistentReservation, WithPersistentReservation()),
-			NewVMIResourceRule(doesVMIRequireCPUForIOThreads, WithIOThreads(vmi.Spec.Domain.IOThreads)),
 		},
 	}
 }

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4931,6 +4931,7 @@ var _ = Describe("Template", func() {
 					expectedMemory := resource.NewScaledQuantity(0, resource.Kilo)
 					expectedMemory.Add(GetMemoryOverhead(&vmi, defaultArch, config.GetConfig().AdditionalGuestMemoryOverheadRatio))
 					expectedMemory.Add(guestMemory)
+					Expect(pod.Spec.Containers[0].Resources.Requests.Memory().Value()).To(BeEquivalentTo(expectedMemory.Value()))
 					Expect(pod.Spec.Containers[0].Resources.Limits.Memory().Value()).To(BeEquivalentTo(expectedMemory.Value()))
 				},
 					Entry("if they are already set in the vmi", true, false),

--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -78,7 +78,7 @@ func (h *HeartBeat) heartBeat(heartBeatInterval time.Duration, stopCh chan struc
 }
 
 func (h *HeartBeat) labelNodeUnschedulable() {
-	retry.OnError(retry.DefaultBackoff, func(err error) bool { return err != nil }, func() error {
+	err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return err != nil }, func() error {
 		now, err := json.Marshal(metav1.Now())
 		if err != nil {
 			log.DefaultLogger().Reason(err).Errorf("Can't determine date")
@@ -98,6 +98,10 @@ func (h *HeartBeat) labelNodeUnschedulable() {
 		}
 		return nil
 	})
+
+	if err != nil {
+		log.Log.Warningf("Failed to set node %s unschedulable", h.host)
+	}
 }
 
 // waitForDevicePlugins gives the device plugins additional time to successfully connect to the kubelet.

--- a/pkg/virt-handler/node-labeller/amd64.go
+++ b/pkg/virt-handler/node-labeller/amd64.go
@@ -26,15 +26,15 @@ type archLabellerAMD64 struct {
 	defaultArchLabeller
 }
 
-func (archLabellerAMD64) shouldLabelNodes() bool {
-	return true
-}
-
 func (archLabellerAMD64) hasHostSupportedFeatures() bool {
 	return true
 }
 
 func (archLabellerAMD64) supportsHostModel() bool {
+	return true
+}
+
+func (archLabellerAMD64) supportsNamedModels() bool {
 	return true
 }
 

--- a/pkg/virt-handler/node-labeller/arch_labeller.go
+++ b/pkg/virt-handler/node-labeller/arch_labeller.go
@@ -35,11 +35,11 @@ const (
 var _ = archLabeller(&defaultArchLabeller{})
 
 type archLabeller interface {
-	shouldLabelNodes() bool
 	defaultVendor() string
 	requirePolicy(policy string) bool
 	hasHostSupportedFeatures() bool
 	supportsHostModel() bool
+	supportsNamedModels() bool
 	arch() string
 }
 
@@ -58,10 +58,6 @@ func newArchLabeller(arch string) archLabeller {
 
 type defaultArchLabeller struct{}
 
-func (defaultArchLabeller) shouldLabelNodes() bool {
-	return false
-}
-
 func (defaultArchLabeller) defaultVendor() string {
 	return ""
 }
@@ -75,6 +71,10 @@ func (defaultArchLabeller) hasHostSupportedFeatures() bool {
 }
 
 func (defaultArchLabeller) supportsHostModel() bool {
+	return false
+}
+
+func (defaultArchLabeller) supportsNamedModels() bool {
 	return false
 }
 

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -180,11 +180,6 @@ func (n *NodeLabeller) loadAll() error {
 }
 
 func (n *NodeLabeller) run() error {
-	obsoleteCPUsx86 := n.clusterConfig.GetObsoleteCPUModels()
-	cpuModels := n.getSupportedCpuModels(obsoleteCPUsx86)
-	cpuFeatures := n.getSupportedCpuFeatures()
-	hostCPUModel := n.GetHostCpuModel()
-
 	originalNode, err := n.nodeClient.Get(context.Background(), n.host, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -194,7 +189,7 @@ func (n *NodeLabeller) run() error {
 
 	if !skipNodeLabelling(node) {
 		//prepare new labels
-		newLabels := n.prepareLabels(node, cpuModels, cpuFeatures, hostCPUModel, obsoleteCPUsx86)
+		newLabels := n.prepareLabels(node)
 		//remove old labeller labels
 		n.removeLabellerLabels(node)
 		//add new labels
@@ -235,27 +230,27 @@ func (n *NodeLabeller) loadHypervFeatures() {
 
 // prepareLabels converts cpu models, features, hyperv features to map[string]string format
 // e.g. "cpu-feature.node.kubevirt.io/Penryn": "true"
-func (n *NodeLabeller) prepareLabels(node *v1.Node, cpuModels []string, cpuFeatures cpuFeatures, hostCpuModel hostCPUModel, obsoleteCPUsx86 map[string]bool) map[string]string {
+func (n *NodeLabeller) prepareLabels(node *v1.Node) map[string]string {
+	obsoleteCPUsx86 := n.clusterConfig.GetObsoleteCPUModels()
+	hostCpuModel := n.GetHostCpuModel()
 	newLabels := make(map[string]string)
-	for key := range cpuFeatures {
-		newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
+
+	if n.arch.hasHostSupportedFeatures() {
+		for key := range n.getSupportedCpuFeatures() {
+			newLabels[kubevirtv1.CPUFeatureLabel+key] = "true"
+		}
 	}
 
-	for _, value := range cpuModels {
-		newLabels[kubevirtv1.CPUModelLabel+value] = "true"
-		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
+	if n.arch.supportsNamedModels() {
+		for _, value := range n.getSupportedCpuModels(obsoleteCPUsx86) {
+			newLabels[kubevirtv1.CPUModelLabel+value] = "true"
+			newLabels[kubevirtv1.SupportedHostModelMigrationCPU+value] = "true"
+		}
 	}
 
-	// Add labels for supported machine types
-	machines := n.getSupportedMachines()
-
-	for _, machine := range machines {
+	for _, machine := range n.getSupportedMachines() {
 		labelKey := kubevirtv1.SupportedMachineTypeLabel + machine.Name
 		newLabels[labelKey] = "true"
-	}
-
-	if _, hostModelObsolete := obsoleteCPUsx86[hostCpuModel.Name]; !hostModelObsolete {
-		newLabels[kubevirtv1.SupportedHostModelMigrationCPU+hostCpuModel.Name] = "true"
 	}
 
 	for _, key := range n.hypervFeatures.items {
@@ -267,19 +262,24 @@ func (n *NodeLabeller) prepareLabels(node *v1.Node, cpuModels []string, cpuFeatu
 		newLabels[kubevirtv1.CPUTimerLabel+"tsc-scalable"] = fmt.Sprintf("%t", n.cpuCounter.Scaling == "yes")
 	}
 
-	for feature := range hostCpuModel.requiredFeatures {
-		newLabels[kubevirtv1.HostModelRequiredFeaturesLabel+feature] = "true"
-	}
-	if _, obsolete := obsoleteCPUsx86[hostCpuModel.Name]; obsolete {
-		newLabels[kubevirtv1.NodeHostModelIsObsoleteLabel] = "true"
-		err := n.alertIfHostModelIsObsolete(node, hostCpuModel.Name, obsoleteCPUsx86)
-		if err != nil {
-			n.logger.Reason(err).Error(err.Error())
+	if n.arch.supportsHostModel() {
+		if _, hostModelObsolete := obsoleteCPUsx86[hostCpuModel.Name]; !hostModelObsolete {
+			newLabels[kubevirtv1.SupportedHostModelMigrationCPU+hostCpuModel.Name] = "true"
+		} else {
+			newLabels[kubevirtv1.NodeHostModelIsObsoleteLabel] = "true"
+			err := n.alertIfHostModelIsObsolete(node, hostCpuModel.Name, obsoleteCPUsx86)
+			if err != nil {
+				n.logger.Reason(err).Error(err.Error())
+			}
 		}
-	}
 
-	newLabels[kubevirtv1.CPUModelVendorLabel+n.cpuModelVendor] = "true"
-	newLabels[kubevirtv1.HostModelCPULabel+hostCpuModel.Name] = "true"
+		for feature := range hostCpuModel.requiredFeatures {
+			newLabels[kubevirtv1.HostModelRequiredFeaturesLabel+feature] = "true"
+		}
+
+		newLabels[kubevirtv1.CPUModelVendorLabel+n.cpuModelVendor] = "true"
+		newLabels[kubevirtv1.HostModelCPULabel+hostCpuModel.Name] = "true"
+	}
 
 	capable, err := isNodeRealtimeCapable()
 	if err != nil {

--- a/pkg/virt-handler/node-labeller/node_labeller.go
+++ b/pkg/virt-handler/node-labeller/node_labeller.go
@@ -359,7 +359,3 @@ func (n *NodeLabeller) getSupportedMachines() []libvirtxml.CapsGuestMachine {
 	}
 	return supportedMachines
 }
-
-func (n *NodeLabeller) ShouldLabelNodes() bool {
-	return n.arch.shouldLabelNodes()
-}

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -288,6 +288,33 @@ var _ = Describe("Node-labeller ", func() {
 		// Added in BeforeEach
 		Expect(node.Labels).To(HaveKey("INeedToBeHere"))
 	})
+
+	DescribeTable("should add machine type labels", func(machines []libvirtxml.CapsGuestMachine, arch string) {
+		guestsCaps[0].Arch.Machines = machines
+
+		initNodeLabeller(&v1.KubeVirt{})
+		nlController.arch = newArchLabeller(arch)
+		mockQueue := testutils.NewMockWorkQueue(nlController.queue)
+		nlController.queue = mockQueue
+
+		mockQueue.ExpectAdds(1)
+		nlController.queue.Add(nodeName)
+		mockQueue.Wait()
+
+		res := nlController.execute()
+		Expect(res).To(BeTrue(), "labeller should complete successfully")
+
+		node := retrieveNode(kubeClient)
+
+		for _, machine := range machines {
+			expectedLabelKey := v1.SupportedMachineTypeLabel + machine.Name
+			Expect(node.Labels).To(HaveKey(expectedLabelKey), "expected machine type label %s to be present", expectedLabelKey)
+		}
+	},
+		Entry("for amd64", []libvirtxml.CapsGuestMachine{{Name: "q35"}, {Name: "q35-rhel9.6.0"}}, amd64),
+		Entry("for arm64", []libvirtxml.CapsGuestMachine{{Name: "virt"}, {Name: "virt-rhel9.6.0"}}, arm64),
+	)
+
 })
 
 func newNode(name string) *k8sv1.Node {

--- a/pkg/virt-handler/node-labeller/node_labeller_test.go
+++ b/pkg/virt-handler/node-labeller/node_labeller_test.go
@@ -288,16 +288,6 @@ var _ = Describe("Node-labeller ", func() {
 		// Added in BeforeEach
 		Expect(node.Labels).To(HaveKey("INeedToBeHere"))
 	})
-
-	DescribeTable("should only label arches that support it", func(arch string, shouldLabel bool) {
-		nlController.arch = newArchLabeller(arch)
-		Expect(nlController.ShouldLabelNodes()).To(Equal(shouldLabel))
-	},
-		Entry(amd64, amd64, true),
-		Entry(arm64, arm64, false),
-		Entry(s390x, s390x, true),
-		Entry("unknown", "unknown", false),
-	)
 })
 
 func newNode(name string) *k8sv1.Node {

--- a/pkg/virt-handler/node-labeller/s390x.go
+++ b/pkg/virt-handler/node-labeller/s390x.go
@@ -26,10 +26,6 @@ var _ = archLabeller(&archLabellerS390X{})
 
 type archLabellerS390X struct{}
 
-func (archLabellerS390X) shouldLabelNodes() bool {
-	return true
-}
-
 func (archLabellerS390X) defaultVendor() string {
 	// On s390x the xml does not include a CPU Vendor, however there is only one company selling them anyway.
 	return "IBM"
@@ -45,6 +41,10 @@ func (archLabellerS390X) hasHostSupportedFeatures() bool {
 }
 
 func (archLabellerS390X) supportsHostModel() bool {
+	return true
+}
+
+func (archLabellerS390X) supportsNamedModels() bool {
 	return true
 }
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -746,7 +746,11 @@ func (c *VirtualMachineController) migrationTargetUpdateVMIStatus(vmi *v1.Virtua
 		log.Log.Object(vmi).Info("The target node received the running migrated domain")
 		now := metav1.Now()
 		vmiCopy.Status.MigrationState.TargetNodeDomainReadyTimestamp = &now
-		c.finalizeMigration(vmiCopy)
+
+		err := c.finalizeMigration(vmiCopy)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !migrations.IsMigrating(vmi) {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2198,7 +2198,11 @@ func (c *VirtualMachineController) closeLauncherClient(vmi *v1.VirtualMachineIns
 		close(clientInfo.DomainPipeStopChan)
 	}
 
-	virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)
+	err := virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)
+	if err != nil {
+		return err
+	}
+
 	c.launcherClients.Delete(vmi.UID)
 	return nil
 }

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6046,7 +6046,7 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: CacheNone, CacheWriteThrough.
+                                  Supported values are: none, writethrough.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -8275,7 +8275,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: CacheNone, CacheWriteThrough.
+                          Supported values are: none, writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -11351,7 +11351,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: CacheNone, CacheWriteThrough.
+                          Supported values are: none, writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -14580,7 +14580,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: CacheNone, CacheWriteThrough.
+                          Supported values are: none, writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -17009,7 +17009,7 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: CacheNone, CacheWriteThrough.
+                                  Supported values are: none, writethrough.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -21508,7 +21508,7 @@ var CRDsValidation map[string]string = map[string]string{
                                       cache:
                                         description: |-
                                           Cache specifies which kvm disk cache mode should be used.
-                                          Supported values are: CacheNone, CacheWriteThrough.
+                                          Supported values are: none, writethrough.
                                         type: string
                                       cdrom:
                                         description: Attach a volume as a cdrom to
@@ -26711,7 +26711,7 @@ var CRDsValidation map[string]string = map[string]string{
                                           cache:
                                             description: |-
                                               Cache specifies which kvm disk cache mode should be used.
-                                              Supported values are: CacheNone, CacheWriteThrough.
+                                              Supported values are: none, writethrough.
                                             type: string
                                           cdrom:
                                             description: Attach a volume as a cdrom
@@ -29007,7 +29007,7 @@ var CRDsValidation map[string]string = map[string]string{
                                   cache:
                                     description: |-
                                       Cache specifies which kvm disk cache mode should be used.
-                                      Supported values are: CacheNone, CacheWriteThrough.
+                                      Supported values are: none, writethrough.
                                     type: string
                                   cdrom:
                                     description: Attach a volume as a cdrom to the

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6046,7 +6046,7 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: none, writethrough.
+                                  Supported values are: none, writethrough, writeback.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -8275,7 +8275,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough.
+                          Supported values are: none, writethrough, writeback.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -11351,7 +11351,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough.
+                          Supported values are: none, writethrough, writeback.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -14580,7 +14580,7 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough.
+                          Supported values are: none, writethrough, writeback.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -17009,7 +17009,7 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: none, writethrough.
+                                  Supported values are: none, writethrough, writeback.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -21508,7 +21508,7 @@ var CRDsValidation map[string]string = map[string]string{
                                       cache:
                                         description: |-
                                           Cache specifies which kvm disk cache mode should be used.
-                                          Supported values are: none, writethrough.
+                                          Supported values are: none, writethrough, writeback.
                                         type: string
                                       cdrom:
                                         description: Attach a volume as a cdrom to
@@ -26711,7 +26711,7 @@ var CRDsValidation map[string]string = map[string]string{
                                           cache:
                                             description: |-
                                               Cache specifies which kvm disk cache mode should be used.
-                                              Supported values are: none, writethrough.
+                                              Supported values are: none, writethrough, writeback.
                                             type: string
                                           cdrom:
                                             description: Attach a volume as a cdrom
@@ -29007,7 +29007,7 @@ var CRDsValidation map[string]string = map[string]string{
                                   cache:
                                     description: |-
                                       Cache specifies which kvm disk cache mode should be used.
-                                      Supported values are: none, writethrough.
+                                      Supported values are: none, writethrough, writeback.
                                     type: string
                                   cdrom:
                                     description: Attach a volume as a cdrom to the

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6046,7 +6046,11 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: none, writethrough, writeback.
+                                  Supported values are:
+                                  none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                                  writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                                  writeback: Guest I/O cached on the host.
+                                  Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -8275,7 +8279,11 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough, writeback.
+                          Supported values are:
+                          none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                          writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                          writeback: Guest I/O cached on the host.
+                          Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -11351,7 +11359,11 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough, writeback.
+                          Supported values are:
+                          none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                          writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                          writeback: Guest I/O cached on the host.
+                          Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -14580,7 +14592,11 @@ var CRDsValidation map[string]string = map[string]string{
                       cache:
                         description: |-
                           Cache specifies which kvm disk cache mode should be used.
-                          Supported values are: none, writethrough, writeback.
+                          Supported values are:
+                          none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                          writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                          writeback: Guest I/O cached on the host.
+                          Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                         type: string
                       cdrom:
                         description: Attach a volume as a cdrom to the vmi.
@@ -17009,7 +17025,11 @@ var CRDsValidation map[string]string = map[string]string{
                               cache:
                                 description: |-
                                   Cache specifies which kvm disk cache mode should be used.
-                                  Supported values are: none, writethrough, writeback.
+                                  Supported values are:
+                                  none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                                  writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                                  writeback: Guest I/O cached on the host.
+                                  Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                                 type: string
                               cdrom:
                                 description: Attach a volume as a cdrom to the vmi.
@@ -21508,7 +21528,11 @@ var CRDsValidation map[string]string = map[string]string{
                                       cache:
                                         description: |-
                                           Cache specifies which kvm disk cache mode should be used.
-                                          Supported values are: none, writethrough, writeback.
+                                          Supported values are:
+                                          none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                                          writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                                          writeback: Guest I/O cached on the host.
+                                          Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                                         type: string
                                       cdrom:
                                         description: Attach a volume as a cdrom to
@@ -26711,7 +26735,11 @@ var CRDsValidation map[string]string = map[string]string{
                                           cache:
                                             description: |-
                                               Cache specifies which kvm disk cache mode should be used.
-                                              Supported values are: none, writethrough, writeback.
+                                              Supported values are:
+                                              none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                                              writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                                              writeback: Guest I/O cached on the host.
+                                              Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                                             type: string
                                           cdrom:
                                             description: Attach a volume as a cdrom
@@ -29007,7 +29035,11 @@ var CRDsValidation map[string]string = map[string]string{
                                   cache:
                                     description: |-
                                       Cache specifies which kvm disk cache mode should be used.
-                                      Supported values are: none, writethrough, writeback.
+                                      Supported values are:
+                                      none: Guest I/O not cached on the host, but may be kept in a disk cache.
+                                      writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+                                      writeback: Guest I/O cached on the host.
+                                      Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
                                     type: string
                                   cdrom:
                                     description: Attach a volume as a cdrom to the

--- a/pkg/virtctl/adm/adm.go
+++ b/pkg/virtctl/adm/adm.go
@@ -16,7 +16,7 @@ func NewCommand() *cobra.Command {
 		Use:   ADM,
 		Short: "Administrate KubeVirt configuration.",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Printf(cmd.UsageString())
+			cmd.Println(cmd.UsageString())
 		},
 	}
 	cmd.AddCommand(logverbosity.NewCommand())

--- a/pkg/virtctl/adm/logverbosity/logverbosity.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity.go
@@ -160,7 +160,7 @@ func usage() string {
 
 // component name to JSON name
 func getJSONNameByComponentName(componentName string) string {
-	var componentNameToJSONName = map[string]string{
+	componentNameToJSONName := map[string]string{
 		"virt-api":        "virtAPI",
 		"virt-controller": "virtController",
 		"virt-handler":    "virtHandler",
@@ -171,7 +171,7 @@ func getJSONNameByComponentName(componentName string) string {
 	return componentNameToJSONName[componentName]
 }
 
-func detectInstallNamespaceAndName(virtClient kubecli.KubevirtClient) (string, string, error) {
+func detectInstallNamespaceAndName(virtClient kubecli.KubevirtClient) (namespace, name string, err error) {
 	kvs, err := virtClient.KubeVirt(k8smetav1.NamespaceAll).List(context.Background(), k8smetav1.ListOptions{})
 	if err != nil {
 		return "", "", fmt.Errorf("could not list KubeVirt CRs across all namespaces: %v", err)
@@ -182,14 +182,14 @@ func detectInstallNamespaceAndName(virtClient kubecli.KubevirtClient) (string, s
 	if len(kvs.Items) > 1 {
 		return "", "", errors.New("invalid kubevirt installation, more than one KubeVirt resource found")
 	}
-	namespace := kvs.Items[0].Namespace
-	name := kvs.Items[0].Name
+	namespace = kvs.Items[0].Namespace
+	name = kvs.Items[0].Name
 	return namespace, name, nil
 }
 
-func hasVerbosityInKV(kv *v1.KubeVirt) (map[string]uint, bool, error) {
-	verbosityMap := map[string]uint{} // key: component name, value: verbosity
-	hasDeveloperConfiguration := true
+func hasVerbosityInKV(kv *v1.KubeVirt) (verbosityMap map[string]uint, hasDeveloperConfiguration bool, err error) {
+	verbosityMap = map[string]uint{} // key: component name, value: verbosity
+	hasDeveloperConfiguration = true
 
 	if kv.Spec.Configuration.DeveloperConfiguration == nil {
 		// If DeveloperConfiguration is absent in the KubeVirt CR, need to add it before adding LogVerbosity.
@@ -235,7 +235,7 @@ func createOutputLines(verbosityVal map[string]uint) []string {
 func createShowMessage(currentLv map[string]uint) []string {
 	// fill the unattended verbosity with default verbosity
 	// key: JSONName, value: verbosity
-	var verbosityVal = map[string]uint{
+	verbosityVal := map[string]uint{
 		"virtAPI":        virtconfig.DefaultVirtAPILogVerbosity,
 		"virtController": virtconfig.DefaultVirtControllerLogVerbosity,
 		"virtHandler":    virtconfig.DefaultVirtHandlerLogVerbosity,

--- a/pkg/virtctl/adm/logverbosity/logverbosity_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_test.go
@@ -345,7 +345,6 @@ var _ = Describe("Log Verbosity", func() {
 			)
 		})
 	})
-
 })
 
 func expectAllComponentVerbosity(kv *v1.KubeVirt, output []uint) {
@@ -359,7 +358,7 @@ func expectAllComponentVerbosity(kv *v1.KubeVirt, output []uint) {
 // create an expected output message
 func createOutputMessage(output []uint) *string {
 	var message string
-	var components = []string{"virt-api", "virt-controller", "virt-handler", "virt-launcher", "virt-operator"}
+	components := []string{"virt-api", "virt-controller", "virt-handler", "virt-launcher", "virt-operator"}
 	for component := 0; component < len(components); component++ {
 		if output[component] == logverbosity.NoFlag {
 			continue

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -646,7 +646,11 @@ type Disk struct {
 	// +optional
 	DedicatedIOThread *bool `json:"dedicatedIOThread,omitempty"`
 	// Cache specifies which kvm disk cache mode should be used.
-	// Supported values are: none, writethrough, writeback.
+	// Supported values are:
+	// none: Guest I/O not cached on the host, but may be kept in a disk cache.
+	// writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.
+	// writeback: Guest I/O cached on the host.
+	// Defaults to none if the storage supports O_DIRECT, otherwise writethrough.
 	// +optional
 	Cache DriverCache `json:"cache,omitempty"`
 	// IO specifies which QEMU disk IO mode should be used.

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -646,7 +646,7 @@ type Disk struct {
 	// +optional
 	DedicatedIOThread *bool `json:"dedicatedIOThread,omitempty"`
 	// Cache specifies which kvm disk cache mode should be used.
-	// Supported values are: none, writethrough.
+	// Supported values are: none, writethrough, writeback.
 	// +optional
 	Cache DriverCache `json:"cache,omitempty"`
 	// IO specifies which QEMU disk IO mode should be used.

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -646,7 +646,7 @@ type Disk struct {
 	// +optional
 	DedicatedIOThread *bool `json:"dedicatedIOThread,omitempty"`
 	// Cache specifies which kvm disk cache mode should be used.
-	// Supported values are: CacheNone, CacheWriteThrough.
+	// Supported values are: none, writethrough.
 	// +optional
 	Cache DriverCache `json:"cache,omitempty"`
 	// IO specifies which QEMU disk IO mode should be used.

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -347,7 +347,7 @@ func (Disk) SwaggerDoc() map[string]string {
 		"bootOrder":         "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
 		"serial":            "Serial provides the ability to specify a serial number for the disk device.\n+optional",
 		"dedicatedIOThread": "dedicatedIOThread indicates this disk should have an exclusive IO Thread.\nEnabling this implies useIOThreads = true.\nDefaults to false.\n+optional",
-		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: none, writethrough, writeback.\n+optional",
+		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are:\nnone: Guest I/O not cached on the host, but may be kept in a disk cache.\nwritethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees.\nwriteback: Guest I/O cached on the host.\nDefaults to none if the storage supports O_DIRECT, otherwise writethrough.\n+optional",
 		"io":                "IO specifies which QEMU disk IO mode should be used.\nSupported values are: native, default, threads.\n+optional",
 		"tag":               "If specified, disk address and its tag will be provided to the guest via config drive metadata\n+optional",
 		"blockSize":         "If specified, the virtual disk will be presented with the given block sizes.\n+optional",

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -347,7 +347,7 @@ func (Disk) SwaggerDoc() map[string]string {
 		"bootOrder":         "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
 		"serial":            "Serial provides the ability to specify a serial number for the disk device.\n+optional",
 		"dedicatedIOThread": "dedicatedIOThread indicates this disk should have an exclusive IO Thread.\nEnabling this implies useIOThreads = true.\nDefaults to false.\n+optional",
-		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: CacheNone, CacheWriteThrough.\n+optional",
+		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: none, writethrough.\n+optional",
 		"io":                "IO specifies which QEMU disk IO mode should be used.\nSupported values are: native, default, threads.\n+optional",
 		"tag":               "If specified, disk address and its tag will be provided to the guest via config drive metadata\n+optional",
 		"blockSize":         "If specified, the virtual disk will be presented with the given block sizes.\n+optional",

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -347,7 +347,7 @@ func (Disk) SwaggerDoc() map[string]string {
 		"bootOrder":         "BootOrder is an integer value > 0, used to determine ordering of boot devices.\nLower values take precedence.\nEach disk or interface that has a boot order must have a unique value.\nDisks without a boot order are not tried if a disk with a boot order exists.\n+optional",
 		"serial":            "Serial provides the ability to specify a serial number for the disk device.\n+optional",
 		"dedicatedIOThread": "dedicatedIOThread indicates this disk should have an exclusive IO Thread.\nEnabling this implies useIOThreads = true.\nDefaults to false.\n+optional",
-		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: none, writethrough.\n+optional",
+		"cache":             "Cache specifies which kvm disk cache mode should be used.\nSupported values are: none, writethrough, writeback.\n+optional",
 		"io":                "IO specifies which QEMU disk IO mode should be used.\nSupported values are: native, default, threads.\n+optional",
 		"tag":               "If specified, disk address and its tag will be provided to the guest via config drive metadata\n+optional",
 		"blockSize":         "If specified, the virtual disk will be presented with the given block sizes.\n+optional",

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
@@ -316,7 +316,7 @@ type VirtualMachineRestoreSpec struct {
 	// If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be
 	// applied to the target manifest before it's created. Patches should fit the target's Kind.
 	//
-	// Example for a patch: {"op": "replace", "path": "/metadata/name", "value": "new-vm-name"}
+	// Example for a patch: {"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/0/macAddress", "value": "00:00:5e:00:53:01"}
 	//
 	// +optional
 	// +listType=atomic

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types_swagger_generated.go
@@ -141,7 +141,7 @@ func (VirtualMachineRestoreSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":        "VirtualMachineRestoreSpec is the spec for a VirtualMachineRestoreresource",
 		"target":  "initially only VirtualMachine type supported",
-		"patches": "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be\napplied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"new-vm-name\"}\n\n+optional\n+listType=atomic",
+		"patches": "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be\napplied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/spec/template/spec/domain/devices/interfaces/0/macAddress\", \"value\": \"00:00:5e:00:53:01\"}\n\n+optional\n+listType=atomic",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19254,7 +19254,7 @@ func schema_kubevirtio_api_core_v1_Disk(ref common.ReferenceCallback) common.Ope
 					},
 					"cache": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough, writeback.",
+							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: none: Guest I/O not cached on the host, but may be kept in a disk cache. writethrough: Guest I/O cached on the host but written through to the physical medium. Slowest but with most guarantees. writeback: Guest I/O cached on the host. Defaults to none if the storage supports O_DIRECT, otherwise writethrough.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19254,7 +19254,7 @@ func schema_kubevirtio_api_core_v1_Disk(ref common.ReferenceCallback) common.Ope
 					},
 					"cache": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: CacheNone, CacheWriteThrough.",
+							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -32752,7 +32752,7 @@ func schema_kubevirtio_api_snapshot_v1alpha1_VirtualMachineRestoreSpec(ref commo
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be applied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/metadata/name\", \"value\": \"new-vm-name\"}",
+							Description: "If the target for the restore does not exist, it will be created. Patches holds JSON patches that would be applied to the target manifest before it's created. Patches should fit the target's Kind.\n\nExample for a patch: {\"op\": \"replace\", \"path\": \"/spec/template/spec/domain/devices/interfaces/0/macAddress\", \"value\": \"00:00:5e:00:53:01\"}",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19254,7 +19254,7 @@ func schema_kubevirtio_api_core_v1_Disk(ref common.ReferenceCallback) common.Ope
 					},
 					"cache": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough.",
+							Description: "Cache specifies which kvm disk cache mode should be used. Supported values are: none, writethrough, writeback.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -44,7 +44,6 @@ go_library(
         "//staging/src/kubevirt.io/api/snapshot/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
-        "//tests/clientcmd:go_default_library",
         "//tests/console:go_default_library",
         "//tests/containerdisk:go_default_library",
         "//tests/decorators:go_default_library",

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -603,7 +603,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 		})
 	})
 
-	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with a DataVolume using Alpine http import", func() {
+	Describe("[rfe_id:3188][crit:high][vendor:cnv-qe@redhat.com][level:system] Starting a VirtualMachine with a DataVolume using http import", func() {
 		var sc string
 
 		BeforeEach(func() {

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"time"
 
+	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
@@ -55,6 +56,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
+	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -301,35 +303,81 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			destPVC = "dest-" + rand.String(5)
 
 		})
-
-		DescribeTable("should migrate the source volume from a source DV to a destination PVC", func(mode string) {
-			volName := "disk0"
-			vm := createVMWithDV(createDV(), volName)
-			// Create dest PVC
-			switch mode {
-			case fsPVC:
-				// Add some overhead to the target PVC for filesystem.
-				libstorage.CreateFSPVC(destPVC, ns, sizeWithOverhead, nil)
-			case blockPVC:
-				libstorage.CreateBlockPVC(destPVC, ns, size)
-			default:
-				Fail("Unrecognized mode")
-			}
-			By("Update volumes")
-			updateVMWithPVC(vm, volName, destPVC)
-			Eventually(func() bool {
-				vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name,
-					metav1.GetOptions{})
+		Context(" destination PVC expansion", decorators.StorageReq, decorators.RequiresVolumeExpansion, func() {
+			DescribeTable("should migrate the source volume from a source DV to a destination PVC", func(mode string) {
+				volName := "disk0"
+				dv := createDV()
+				vmi := libvmi.New(
+					libvmi.WithNamespace(ns),
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
+					libvmi.WithResourceMemory("128Mi"),
+					libvmi.WithDataVolume(volName, dv.Name),
+					libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot()),
+				)
+				vm := libvmi.NewVirtualMachine(vmi,
+					libvmi.WithRunStrategy(virtv1.RunStrategyAlways),
+					libvmi.WithDataVolumeTemplate(dv),
+				)
+				vm, err := virtClient.VirtualMachine(ns).Create(context.Background(), vm, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				claim := storagetypes.PVCNameFromVirtVolume(&vmi.Spec.Volumes[0])
-				return claim == destPVC
-			}, 120*time.Second, time.Second).Should(BeTrue())
-			waitForMigrationToSucceed(virtClient, vm.Name, ns)
-		},
-			Entry("to a filesystem volume", fsPVC),
-			Entry("to a block volume", decorators.RequiresBlockStorage, blockPVC),
-		)
+				Eventually(matcher.ThisVM(vm), 360*time.Second, 1*time.Second).Should(matcher.BeReady())
+				libwait.WaitForSuccessfulVMIStart(vmi)
 
+				// Create dest PVC
+				var dstPVC *k8sv1.PersistentVolumeClaim
+				switch mode {
+				case fsPVC:
+					// Add some overhead to the target PVC for filesystem.
+					dstPVC = libstorage.CreateFSPVC(destPVC, ns, sizeWithOverhead, nil)
+				case blockPVC:
+					dstPVC = libstorage.CreateBlockPVC(destPVC, ns, size)
+				default:
+					Fail("Unrecognized mode")
+				}
+				Expect(dstPVC.Spec.StorageClassName).ToNot(BeNil())
+				if !volumeExpansionAllowed(*dstPVC.Spec.StorageClassName) {
+					Fail("Fail when volume expansion storage class not available")
+				}
+
+				By("Update volumes")
+				updateVMWithPVC(vm, volName, destPVC)
+				Eventually(func() bool {
+					vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name,
+						metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					claim := storagetypes.PVCNameFromVirtVolume(&vmi.Spec.Volumes[0])
+					return claim == destPVC
+				}, 120*time.Second, time.Second).Should(BeTrue())
+				waitForMigrationToSucceed(virtClient, vm.Name, ns)
+
+				By("Expanding the destination PVC")
+				p, err := patch.New(
+					patch.WithAdd("/spec/resources/requests/storage", resource.MustParse("4Gi")),
+				).GeneratePayload()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Patch(context.Background(),
+					destPVC, types.JSONPatchType, p, metav1.PatchOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Expecting the VirtualMachineInstance console")
+				Expect(console.LoginToCirros(vmi)).To(Succeed())
+
+				By("Waiting for notification about size change")
+				Eventually(func() error {
+					err := console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "\n"},
+						&expect.BExp{R: console.PromptExpression},
+						&expect.BSnd{S: "[ $(lsblk /dev/vda -o SIZE -n |sed -e \"s/ //g\") == \"4G\" ] && true\n"},
+						&expect.BExp{R: "0"},
+					}, 10)
+					return err
+				}, 120).Should(BeNil())
+			},
+				Entry("to a filesystem volume", fsPVC),
+				Entry("to a block volume", decorators.RequiresBlockStorage, blockPVC),
+			)
+		})
 		It("should migrate the source volume from a source DV to a destination DV", func() {
 			volName := "disk0"
 			vm := createVMWithDV(createDV(), volName)

--- a/tools/util/marshaller_test.go
+++ b/tools/util/marshaller_test.go
@@ -29,11 +29,7 @@ import (
 
 func TestMarshallObject(t *testing.T) {
 	var imagePullSecret []v1.LocalObjectReference
-	handler, err := components.NewHandlerDaemonSet("{{.Namespace}}", "", "{{.DockerPrefix}}", "{{.DockerTag}}", "", "", "", "", "", "", "", "", v1.PullIfNotPresent, imagePullSecret, nil, "2", nil, false)
-	if err != nil {
-		t.Fatalf("error generating virt-handler deployment for marshall test %v", err)
-	}
-
+	handler := components.NewHandlerDaemonSet("{{.Namespace}}", "", "{{.DockerPrefix}}", "{{.DockerTag}}", "", "", "", "", "", "", "", "", "", "", v1.PullIfNotPresent, imagePullSecret, nil, "2", nil, false)
 	writer := strings.Builder{}
 
 	MarshallObject(handler, &writer)


### PR DESCRIPTION
<!--  
  Thanks for sending a pull request! Please follow the contribution guidelines:
  1. Create this PR as draft if it's still being developed.
  2. Link the issue using "Fixes #" so it closes automatically when merged.
  3. Follow Kubernetes release note conventions.
-->

### What this PR does

Before this PR:
- Several test failures in `volume_metrics.go` and `volumeattributesclass.go` had minimal or unclear failure messages.
- Developers had to manually trace logs to understand what went wrong, especially in CI.

After this PR:
- Improved failure messages in the two affected test files.
- Errors now explicitly describe what went wrong, such as mismatched status counts or latency metrics.
- These enhanced messages help contributors and maintainers identify failures more efficiently.

---

### Fixes
Fixes #10347

---

### Why we need it and why it was done in this way

This change improves the **developer experience** by making failure outputs in e2e tests clearer and actionable. By updating only the messages (without changing test logic), we reduce the time to diagnose issues without introducing risk.

The work was done incrementally, and each message was carefully written to follow existing patterns and retain Gomega expectations. The intent is to **aid both new contributors and experienced maintainers** who rely on precise test logs.

---

### Alternatives considered

- Rewriting tests for more structural output was considered, but that would have expanded the scope.
- Instead, we limited changes to enhancing log content using `fmt.Sprintf` within `Expect` calls.

---

### Special notes for your reviewer

Thanks to my mentor **Javier Cano Cano** for his continuous support and guidance throughout this contribution.  
All feedback is welcome — I'm happy to revise the messages further if needed.

---

### Checklist

- [x] PR title clearly states the intent of the change
- [x] Only test messages were updated — no core logic altered
- [x] Manually verified the changes with test runs
- [x] Follows the KubeVirt [contribution guidelines](https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md)
- [x] No user-facing feature or API change involved
- [x] No additional documentation or user-guide required

---

### Release note
```release-note
Improve test failure messages for ResizePolicy-related storage tests to assist in debugging and maintainability.
